### PR TITLE
Fix `type_traits.h` to address compiler warnings around using deprecated methods

### DIFF
--- a/api/include/opentelemetry/config.h
+++ b/api/include/opentelemetry/config.h
@@ -3,12 +3,9 @@
 
 #pragma once
 
-#ifndef __has_include
-#  define OPENTELEMETRY_HAS_INCLUDE(x) 0
-#else
-#  define OPENTELEMETRY_HAS_INCLUDE(x) __has_include(x)
-#endif
+#include <type_traits>  // IWYU pragma: keep
 
-#if !defined(__GLIBCXX__) || OPENTELEMETRY_HAS_INCLUDE(<codecvt>)  // >= libstdc++-5
+#if !defined(__GLIBCXX__) || (defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7) || \
+    (defined(__GLIBCXX__) && __GLIBCXX__ >= 20150422)  // >= libstdc++-5
 #  define OPENTELEMETRY_TRIVIALITY_TYPE_TRAITS
 #endif


### PR DESCRIPTION
## Description

`__has_trivial_copy` has been deprecated in favor of `__is_trivially_assignable`. This is causing issues while bumping up the Open Telemetry dependency in Envoy from v1.29 => v1.20 [[See This](https://github.com/envoyproxy/envoy/pull/39182)].

## Changes

We have created a patch in Envoy and are trying to upstream the fixes to get a clean patch-free build.